### PR TITLE
Json simple jax-rs entity provider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,12 @@
     </developers>
     <dependencies>
         <dependency>
+            <!-- For JsonSimpleMessageBodyHandler.java. -->
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <version>2.1-m01</version>
+        </dependency>
+        <dependency>
             <!-- For testing basic functionality of the library. -->
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/src/main/java/org/json/simple/JsonSimpleMessageBodyHandler.java
+++ b/src/main/java/org/json/simple/JsonSimpleMessageBodyHandler.java
@@ -1,0 +1,100 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.flrv.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Type;
+import java.lang.annotation.Annotation;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.MessageBodyWriter;
+
+import org.json.simple.DeserializationException;
+import org.json.simple.JsonObject;
+import org.json.simple.Jsoner;
+
+/**
+ *
+ * @author wlt
+ */
+public class JsonSimpleMessageBodyHandler implements MessageBodyWriter<Object>,
+                                                     MessageBodyReader<Object> {
+
+  private static final String UTF_8 = "UTF-8";
+
+    @Override
+    public boolean isReadable(Class<?> type,
+                            Type genericType,
+                            Annotation[] annotations,
+                            MediaType mediaType) {
+        return true;
+    }
+ 
+    @Override
+    public Object readFrom(Class<Object> type,
+                           Type genericType,
+                           Annotation[] annotations,
+                           MediaType mediaType,
+                           MultivaluedMap<String, String> httpHeaders,
+                           InputStream entityStream) throws IOException {
+        Object json = new JsonObject();
+        InputStreamReader streamReader = null;
+        try {
+            streamReader = new InputStreamReader(entityStream, UTF_8);
+            json = Jsoner.deserialize(streamReader);
+        } catch (UnsupportedEncodingException | DeserializationException ex) {
+            Logger.getLogger(JsonSimpleMessageBodyHandler.class.getName()).log(Level.SEVERE, null, ex);
+        } finally {
+            if(streamReader!=null)
+                streamReader.close();
+        }
+        return(json);
+    }
+ 
+    @Override
+    public boolean isWriteable(Class<?> type,
+                             Type genericType,
+                             Annotation[] annotations,
+                             MediaType mediaType) {
+        return true;
+    }
+ 
+    @Override
+    public long getSize(Object object,
+                      Class<?> type,
+                      Type genericType,
+                      Annotation[] annotations,
+                      MediaType mediaType) {
+        return -1;
+    }
+ 
+    @Override
+    public void writeTo(Object object,
+                        Class<?> type,
+                        Type genericType,
+                        Annotation[] annotations,
+                        MediaType mediaType,
+                        MultivaluedMap<String, Object> httpHeaders,
+                        OutputStream entityStream) throws IOException,
+                                                          WebApplicationException {
+        OutputStreamWriter writer = new OutputStreamWriter(entityStream, UTF_8);
+        try {
+            writer.write(((JsonObject)object).toJson());
+        } finally {
+            writer.close();
+        }
+    }
+}


### PR DESCRIPTION
Here is a jax-rs entity provider for json-simple. Handles both read/write. Usage at least in Jersey is as follows.

`final Client client = ClientBuilder.newBuilder()
                .register(feature)
                .register(JsonSimpleMessageBodyHandler.class)
                .build();`

then
`JsonObject json = response.readEntity(JsonObject.class);`

Seems to work, may be improved upon. Not sure about location. It may be some optional module rather than main part of json-simple, as to not force the dependency on others. I will leave that up to you. Having the dependency is moot for me since I am already using jax-rs. 

Not to concerned with license, left that off of file. Credit would be nice, but I am fine with the license that the rest of the code is under, Clifton Labs Apache 2.0.  Feel free to modify as needed.
