### PR TITLE
Spike json handler

### DIFF
--- a/src/main/java/org/json/simple/JsonAccumulator.java
+++ b/src/main/java/org/json/simple/JsonAccumulator.java
@@ -1,0 +1,76 @@
+package org.json.simple;
+
+import java.util.Deque;
+import java.util.LinkedList;
+
+public class JsonAccumulator implements JsonHandler {
+
+    private final Deque<Object> valueStack = new LinkedList<>();
+
+    @Override
+    public void startObject(Jsoner.States state) {
+        JsonObject object = new JsonObject();
+        meld(object, state);
+        this.valueStack.addLast(object);
+    }
+
+    @Override
+    public void key(String key) {
+        this.valueStack.addLast(key);
+    }
+
+    @Override
+    public boolean endObject(int returnCount) {
+        boolean b = this.valueStack.size() > returnCount;
+        if (b) {
+            this.valueStack.removeLast();
+        }
+        return b;
+    }
+
+    @Override
+    public void startArray(Jsoner.States state) {
+        JsonArray array = new JsonArray();
+        meld(array, state);
+        this.valueStack.addLast(array);
+    }
+
+    @Override
+    public boolean endArray(int returnCount) {
+        boolean b = this.valueStack.size() > returnCount;
+        if (b) {
+            this.valueStack.removeLast();
+        }
+        return b;
+    }
+
+    @Override
+    public void datum(Object value, Jsoner.States state) {
+        if (state == Jsoner.States.INITIAL) {
+            this.valueStack.addLast(value);
+        } else {
+            meld(value, state);
+        }
+    }
+
+    private void meld(Object object, Jsoner.States state) {
+        switch (state) {
+            case INITIAL:
+                break;
+            case PARSING_ARRAY:
+                JsonArray parentArray = (JsonArray) this.valueStack.getLast();
+                parentArray.add(object);
+                break;
+            case PARSING_OBJECT:
+                String key = (String) this.valueStack.removeLast();
+                JsonObject parentObject = (JsonObject) this.valueStack.getLast();
+                parentObject.put(key, object);
+                break;
+        }
+    }
+
+    JsonArray finish() {
+        return new JsonArray(this.valueStack);
+    }
+
+}

--- a/src/main/java/org/json/simple/JsonHandler.java
+++ b/src/main/java/org/json/simple/JsonHandler.java
@@ -1,0 +1,17 @@
+package org.json.simple;
+
+public interface JsonHandler {
+
+    void startObject(Jsoner.States state);
+
+    void key(String key);
+
+    boolean endObject(int returnCount);
+
+    void startArray(Jsoner.States state);
+
+    boolean endArray(int returnCount);
+
+    void datum(Object value, Jsoner.States state);
+
+}

--- a/src/main/java/org/json/simple/Jsoner.java
+++ b/src/main/java/org/json/simple/Jsoner.java
@@ -112,43 +112,12 @@ public class Jsoner{
             switch(currentState){
                 case DONE:
                     /* The parse has finished a JSON value. */
-                    if(flags.contains(DeserializationOptions.ALLOW_CONCATENATED_JSON_VALUES) && !Yytoken.Types.END.equals(token.getType())){
-                        /* Since there could be multiple JSON values treat the parse as if it is in the initial state. */
-                        returnCount += 1;
-                        switch(token.getType()){
-                            case DATUM:
-                                /* A boolean, null, Number, or String could be detected. */
-                                if(flags.contains(DeserializationOptions.ALLOW_JSON_DATA)){
-                                    valueStack.addLast(token.getValue());
-                                    stateStack.addLast(States.DONE);
-                                }else{
-                                    throw new DeserializationException(lexer.getPosition(), DeserializationException.Problems.DISALLOWED_TOKEN, token);
-                                }
-                                break;
-                            case LEFT_BRACE:
-                                /* An object is detected. */
-                                if(flags.contains(DeserializationOptions.ALLOW_JSON_OBJECTS)){
-                                    valueStack.addLast(new JsonObject());
-                                    stateStack.addLast(States.PARSING_OBJECT);
-                                }else{
-                                    throw new DeserializationException(lexer.getPosition(), DeserializationException.Problems.DISALLOWED_TOKEN, token);
-                                }
-                                break;
-                            case LEFT_SQUARE:
-                                /* An array is detected. */
-                                if(flags.contains(DeserializationOptions.ALLOW_JSON_ARRAYS)){
-                                    valueStack.addLast(new JsonArray());
-                                    stateStack.addLast(States.PARSING_ARRAY);
-                                }else{
-                                    throw new DeserializationException(lexer.getPosition(), DeserializationException.Problems.DISALLOWED_TOKEN, token);
-                                }
-                                break;
-                            default:
-                                /* Neither a JSON array or object was detected. */
-                                throw new DeserializationException(lexer.getPosition(), DeserializationException.Problems.UNEXPECTED_TOKEN, token);
-                        }
+                    if(!flags.contains(DeserializationOptions.ALLOW_CONCATENATED_JSON_VALUES) || Yytoken.Types.END.equals(token.getType())){
+                        break;
                     }
-                    break;
+                    /* Since there could be multiple JSON values treat the parse as if it is in the initial state. */
+                    returnCount += 1;
+                    /* Fall through to the case for the initial state */
                 case INITIAL:
                     /* The parse has just started. */
                     switch(token.getType()){

--- a/src/main/java/org/json/simple/Jsoner.java
+++ b/src/main/java/org/json/simple/Jsoner.java
@@ -58,7 +58,7 @@ public class Jsoner{
     }
 
     /** The possible States of a JSON deserializer. */
-    private static enum States{
+    public static enum States{
         /** Post-parsing state. */
         DONE,
         /** Pre-parsing state. */
@@ -102,7 +102,7 @@ public class Jsoner{
         States currentState;
         int returnCount = 1;
         final LinkedList<States> stateStack = new LinkedList<States>();
-        final LinkedList<Object> valueStack = new LinkedList<Object>();
+        final JsonAccumulator valueStack = new JsonAccumulator();
         stateStack.addLast(States.INITIAL);
         //System.out.println("//////////DESERIALIZING//////////");
         do{
@@ -124,7 +124,7 @@ public class Jsoner{
                         case DATUM:
                             /* A boolean, null, Number, or String could be detected. */
                             if(flags.contains(DeserializationOptions.ALLOW_JSON_DATA)){
-                                valueStack.addLast(token.getValue());
+                                valueStack.datum(token.getValue(), States.INITIAL);
                                 stateStack.addLast(States.DONE);
                             }else{
                                 throw new DeserializationException(lexer.getPosition(), DeserializationException.Problems.DISALLOWED_TOKEN, token);
@@ -133,7 +133,7 @@ public class Jsoner{
                         case LEFT_BRACE:
                             /* An object is detected. */
                             if(flags.contains(DeserializationOptions.ALLOW_JSON_OBJECTS)){
-                                valueStack.addLast(new JsonObject());
+                                valueStack.startObject(States.INITIAL);
                                 stateStack.addLast(States.PARSING_OBJECT);
                             }else{
                                 throw new DeserializationException(lexer.getPosition(), DeserializationException.Problems.DISALLOWED_TOKEN, token);
@@ -142,7 +142,7 @@ public class Jsoner{
                         case LEFT_SQUARE:
                             /* An array is detected. */
                             if(flags.contains(DeserializationOptions.ALLOW_JSON_ARRAYS)){
-                                valueStack.addLast(new JsonArray());
+                                valueStack.startArray(States.INITIAL);
                                 stateStack.addLast(States.PARSING_ARRAY);
                             }else{
                                 throw new DeserializationException(lexer.getPosition(), DeserializationException.Problems.DISALLOWED_TOKEN, token);
@@ -164,33 +164,24 @@ public class Jsoner{
                             break;
                         case DATUM:
                             /* The parse found an element of the array. */
-                            JsonArray val = (JsonArray)valueStack.getLast();
-                            val.add(token.getValue());
+                            valueStack.datum(token.getValue(), States.PARSING_ARRAY);
                             stateStack.addLast(currentState);
                             break;
                         case LEFT_BRACE:
                             /* The parse found an object in the array. */
-                            val = (JsonArray)valueStack.getLast();
-                            final JsonObject object = new JsonObject();
-                            val.add(object);
-                            valueStack.addLast(object);
+                            valueStack.startObject(States.PARSING_ARRAY);
                             stateStack.addLast(currentState);
                             stateStack.addLast(States.PARSING_OBJECT);
                             break;
                         case LEFT_SQUARE:
                             /* The parse found another array in the array. */
-                            val = (JsonArray)valueStack.getLast();
-                            final JsonArray array = new JsonArray();
-                            val.add(array);
-                            valueStack.addLast(array);
+                            valueStack.startArray(States.PARSING_ARRAY);
                             stateStack.addLast(currentState);
                             stateStack.addLast(States.PARSING_ARRAY);
                             break;
                         case RIGHT_SQUARE:
                             /* The parse found the end of the array. */
-                            if(valueStack.size() > returnCount){
-                                valueStack.removeLast();
-                            }else{
+                            if(!valueStack.endArray(returnCount)){
                                 /* The parse has been fully resolved. */
                                 stateStack.addLast(States.DONE);
                             }
@@ -214,7 +205,7 @@ public class Jsoner{
                                 /* JSON keys are always strings, strings are not always JSON keys but it is going to be
                                  * treated as one. Continue parsing the object. */
                                 final String key = (String)token.getValue();
-                                valueStack.addLast(key);
+                                valueStack.key(key);
                                 stateStack.addLast(currentState);
                                 stateStack.addLast(States.PARSING_ENTRY);
                             }else{
@@ -224,10 +215,7 @@ public class Jsoner{
                             break;
                         case RIGHT_BRACE:
                             /* The parse has found the end of the object. */
-                            if(valueStack.size() > returnCount){
-                                /* There are unresolved values remaining. */
-                                valueStack.removeLast();
-                            }else{
+                            if(!valueStack.endObject(returnCount)){
                                 /* The parse has been fully resolved. */
                                 stateStack.addLast(States.DONE);
                             }
@@ -247,26 +235,18 @@ public class Jsoner{
                             break;
                         case DATUM:
                             /* The parse has found a value for the parsed pair key. */
-                            String key = (String)valueStack.removeLast();
-                            JsonObject parent = (JsonObject)valueStack.getLast();
-                            parent.put(key, token.getValue());
+                            valueStack.datum(token.getValue(), States.PARSING_OBJECT);
+                            String key;
+                            JsonObject parent;
                             break;
                         case LEFT_BRACE:
                             /* The parse has found an object for the parsed pair key. */
-                            key = (String)valueStack.removeLast();
-                            parent = (JsonObject)valueStack.getLast();
-                            final JsonObject object = new JsonObject();
-                            parent.put(key, object);
-                            valueStack.addLast(object);
+                            valueStack.startObject(States.PARSING_OBJECT);
                             stateStack.addLast(States.PARSING_OBJECT);
                             break;
                         case LEFT_SQUARE:
                             /* The parse has found an array for the parsed pair key. */
-                            key = (String)valueStack.removeLast();
-                            parent = (JsonObject)valueStack.getLast();
-                            final JsonArray array = new JsonArray();
-                            parent.put(key, array);
-                            valueStack.addLast(array);
+                            valueStack.startArray(States.PARSING_OBJECT);
                             stateStack.addLast(States.PARSING_ARRAY);
                             break;
                         default:
@@ -285,7 +265,7 @@ public class Jsoner{
             /* If we're not at the END and DONE then do the above again. */
         }while(!(States.DONE.equals(currentState) && Yytoken.Types.END.equals(token.getType())));
         //System.out.println("!!!!!!!!!!DESERIALIZED!!!!!!!!!!");
-        return new JsonArray(valueStack);
+        return valueStack.finish();
     }
 
     /** A convenience method that assumes a StringReader to deserialize a string.


### PR DESCRIPTION
The ContentHandler interface has been deprecated. The JSONParser class has also been deprecated, and its replacement, Jsoner, does not have equivalents of the parse(Reader, ContentHandler) family of methods. There is therefore no non-deprecated way to parse JSON in a streaming way.

This PR is a rough attempt at adding a new way to do streaming JSON parsing. I think it's mostly okay, with some rough edges:

* At the moment, the JsonHandler interface gets involved in the decision about how to handle a document with multiple JSON objects in via the parameter and return value of endObject and endArray. I think it would be better to lift that up entirely into Jsoner, probably by separating the two roles of the valueStack into a listOfTopLevelValues held in the Jsoner, and a currentValueStack in the JsonAccumulator. Jsoner could then take complete responsibility for keeping track of the depth (via a simple count) and moving completed objects from the accumulator to the list. That would leave endObject and endArray taking no parameter and returning void.

* I made States public, but only three of its values are ever passed to the JsonHandler. It might be better to use a separate enum for this. It might be even better to get rid of the state parameter to the JsonHandler methods entirely, and have it track its own state - i think all it would need to do is look at the class of the object on the top of the valueStack to decide what to do.

* I haven't followed your coding style, or written javadoc, or written tests. Hey, it's a spike!

What do you think?