### PR TITLE
Fix off-by-one errors when serializing Java arrays (with tests).

### DIFF
--- a/src/main/java/com/github/cliftonlabs/json_simple/Jsoner.java
+++ b/src/main/java/com/github/cliftonlabs/json_simple/Jsoner.java
@@ -614,6 +614,11 @@ public class Jsoner{
 			writableDestination.write('"');
 			writableDestination.write(Jsoner.escape((String)jsonSerializable));
 			writableDestination.write('"');
+		}else if (jsonSerializable instanceof Character) {
+			/* Make sure the string is properly escaped. */
+			//writableDestination.write('"');
+			writableDestination.write(Jsoner.escape(jsonSerializable.toString()));
+			//writableDestination.write('"');
 		}else if(jsonSerializable instanceof Double){
 			if(((Double)jsonSerializable).isInfinite() || ((Double)jsonSerializable).isNaN()){
 				/* Infinite and not a number are not supported by the JSON specification, so null is used instead. */
@@ -671,8 +676,8 @@ public class Jsoner{
 			final byte[] writableArray = (byte[])jsonSerializable;
 			final int numberOfElements = writableArray.length;
 			writableDestination.write('[');
-			for(int i = 1; i <= numberOfElements; i++){
-				if(i == numberOfElements){
+			for(int i = 0; i < numberOfElements; i++){
+				if(i == numberOfElements - 1){
 					Jsoner.serialize(writableArray[i], writableDestination, flags);
 				}else{
 					Jsoner.serialize(writableArray[i], writableDestination, flags);
@@ -685,8 +690,8 @@ public class Jsoner{
 			final short[] writableArray = (short[])jsonSerializable;
 			final int numberOfElements = writableArray.length;
 			writableDestination.write('[');
-			for(int i = 1; i <= numberOfElements; i++){
-				if(i == numberOfElements){
+			for(int i = 0; i < numberOfElements; i++){
+				if(i == numberOfElements - 1){
 					Jsoner.serialize(writableArray[i], writableDestination, flags);
 				}else{
 					Jsoner.serialize(writableArray[i], writableDestination, flags);
@@ -699,8 +704,8 @@ public class Jsoner{
 			final int[] writableArray = (int[])jsonSerializable;
 			final int numberOfElements = writableArray.length;
 			writableDestination.write('[');
-			for(int i = 1; i <= numberOfElements; i++){
-				if(i == numberOfElements){
+			for(int i = 0; i < numberOfElements; i++){
+				if(i == numberOfElements - 1){
 					Jsoner.serialize(writableArray[i], writableDestination, flags);
 				}else{
 					Jsoner.serialize(writableArray[i], writableDestination, flags);
@@ -713,8 +718,8 @@ public class Jsoner{
 			final long[] writableArray = (long[])jsonSerializable;
 			final int numberOfElements = writableArray.length;
 			writableDestination.write('[');
-			for(int i = 1; i <= numberOfElements; i++){
-				if(i == numberOfElements){
+			for(int i = 0; i < numberOfElements; i++){
+				if(i == numberOfElements - 1){
 					Jsoner.serialize(writableArray[i], writableDestination, flags);
 				}else{
 					Jsoner.serialize(writableArray[i], writableDestination, flags);
@@ -727,8 +732,8 @@ public class Jsoner{
 			final float[] writableArray = (float[])jsonSerializable;
 			final int numberOfElements = writableArray.length;
 			writableDestination.write('[');
-			for(int i = 1; i <= numberOfElements; i++){
-				if(i == numberOfElements){
+			for(int i = 0; i < numberOfElements; i++){
+				if(i == numberOfElements - 1){
 					Jsoner.serialize(writableArray[i], writableDestination, flags);
 				}else{
 					Jsoner.serialize(writableArray[i], writableDestination, flags);
@@ -741,8 +746,8 @@ public class Jsoner{
 			final double[] writableArray = (double[])jsonSerializable;
 			final int numberOfElements = writableArray.length;
 			writableDestination.write('[');
-			for(int i = 1; i <= numberOfElements; i++){
-				if(i == numberOfElements){
+			for(int i = 0; i < numberOfElements; i++){
+				if(i == numberOfElements - 1){
 					Jsoner.serialize(writableArray[i], writableDestination, flags);
 				}else{
 					Jsoner.serialize(writableArray[i], writableDestination, flags);
@@ -755,8 +760,8 @@ public class Jsoner{
 			final boolean[] writableArray = (boolean[])jsonSerializable;
 			final int numberOfElements = writableArray.length;
 			writableDestination.write('[');
-			for(int i = 1; i <= numberOfElements; i++){
-				if(i == numberOfElements){
+			for(int i = 0; i < numberOfElements; i++){
+				if(i == numberOfElements - 1){
 					Jsoner.serialize(writableArray[i], writableDestination, flags);
 				}else{
 					Jsoner.serialize(writableArray[i], writableDestination, flags);
@@ -769,8 +774,8 @@ public class Jsoner{
 			final char[] writableArray = (char[])jsonSerializable;
 			final int numberOfElements = writableArray.length;
 			writableDestination.write("[\"");
-			for(int i = 1; i <= numberOfElements; i++){
-				if(i == numberOfElements){
+			for(int i = 0; i < numberOfElements; i++){
+				if(i == numberOfElements - 1){
 					Jsoner.serialize(writableArray[i], writableDestination, flags);
 				}else{
 					Jsoner.serialize(writableArray[i], writableDestination, flags);
@@ -783,8 +788,8 @@ public class Jsoner{
 			final Object[] writableArray = (Object[])jsonSerializable;
 			final int numberOfElements = writableArray.length;
 			writableDestination.write('[');
-			for(int i = 1; i <= numberOfElements; i++){
-				if(i == numberOfElements){
+			for(int i = 0; i < numberOfElements; i++){
+				if(i == numberOfElements - 1){
 					Jsoner.serialize(writableArray[i], writableDestination, flags);
 				}else{
 					Jsoner.serialize(writableArray[i], writableDestination, flags);

--- a/src/test/java/com/github/cliftonlabs/json_simple/JsonerTest.java
+++ b/src/test/java/com/github/cliftonlabs/json_simple/JsonerTest.java
@@ -60,6 +60,33 @@ public class JsonerTest{
 		serialized = new StringWriter();
 		Jsoner.serializeCarelessly(new JsonArray(), serialized);
 		Assert.assertEquals("[]", serialized.toString());
+		serialized = new StringWriter();
+		Jsoner.serialize(new boolean[] {true, false, true}, serialized);
+		Assert.assertEquals("[true,false,true]", serialized.toString());
+		serialized = new StringWriter();
+		Jsoner.serialize(new byte[] {0, 1, 2}, serialized);
+		Assert.assertEquals("[0,1,2]", serialized.toString());
+		serialized = new StringWriter();
+		Jsoner.serialize(new short[] {0, 1, 2}, serialized);
+		Assert.assertEquals("[0,1,2]", serialized.toString());
+		serialized = new StringWriter();
+		Jsoner.serialize(new int[] {0, 1, 2}, serialized);
+		Assert.assertEquals("[0,1,2]", serialized.toString());
+		serialized = new StringWriter();
+		Jsoner.serialize(new long[] {0, 1, 2}, serialized);
+		Assert.assertEquals("[0,1,2]", serialized.toString());
+		serialized = new StringWriter();
+		Jsoner.serialize(new float[] {0.0f, 1.0f, 2.0f}, serialized);
+		Assert.assertEquals("[0.0,1.0,2.0]", serialized.toString());
+		serialized = new StringWriter();
+		Jsoner.serialize(new double[] {0.0, 1.0, 2.0}, serialized);
+		Assert.assertEquals("[0.0,1.0,2.0]", serialized.toString());
+		serialized = new StringWriter();
+		Jsoner.serialize(new char[] {'a', 'b', 'c'}, serialized);
+		Assert.assertEquals("[\"a\",\"b\",\"c\"]", serialized.toString());
+		serialized = new StringWriter();
+		Jsoner.serialize(new Object[] {"a", "b", "d"}, serialized);
+		Assert.assertEquals("[\"a\",\"b\",\"d\"]", serialized.toString());
 	}
 
 	/** Ensures booleans are directly deserializable.


### PR DESCRIPTION
Noticed a few bugs reading through the code, mostly iterating through primitive arrays from 1 to array length instead of 0 to array length - 1. Added some tests to confirm, then fixed the errors. Also noticed that it threw an exception when passing an array of characters because it didn't recognize `Character` objects. (Not sure why the quotes are not needed, so commented those lines for now).