### PR TITLE
feature: Added way to efficiently navigate through already known JSON

### DIFF
--- a/src/main/java/com/github/cliftonlabs/json_simple/Accessor.java
+++ b/src/main/java/com/github/cliftonlabs/json_simple/Accessor.java
@@ -1,0 +1,13 @@
+package com.github.cliftonlabs.json_simple;
+
+public interface Accessor {
+    JsonArray asArray();
+
+    JsonObject asJsonObject();
+
+    boolean isArray();
+
+    boolean isJsonObject();
+
+    boolean isNull();
+}

--- a/src/main/java/com/github/cliftonlabs/json_simple/Jsoner.java
+++ b/src/main/java/com/github/cliftonlabs/json_simple/Jsoner.java
@@ -300,6 +300,15 @@ public class Jsoner{
 		return returnable;
 	}
 
+	public static ParseResult deserializeWrapped(final String input) throws JsonException {
+		Object result = deserialize(input);
+		if(result instanceof Jsonable) {
+			return new ParseResult((Jsonable) result);
+		} else {
+			throw new RuntimeException("Input is not applicable for wrapped navigation");
+		}
+	}
+
 	/** A convenience method that assumes a JsonArray must be deserialized.
 	 * @param deserializable representing content to be deserializable as a JsonArray.
 	 * @param defaultValue representing what would be returned if deserializable isn't a JsonArray or an IOException,

--- a/src/main/java/com/github/cliftonlabs/json_simple/ParseResult.java
+++ b/src/main/java/com/github/cliftonlabs/json_simple/ParseResult.java
@@ -1,0 +1,167 @@
+package com.github.cliftonlabs.json_simple;
+
+import java.math.BigDecimal;
+
+/**
+ * Wrapped deserialize result
+ * Used to fastly navigate through resulted JSON
+ * @author <a href="https://github.com/SashaSemenishchev">SashaSemenishchev</a>
+ */
+public class ParseResult implements Accessor {
+    private final Jsonable result;
+
+    public ParseResult(Jsonable result) {
+        this.result = result;
+    }
+
+    /**
+     *
+     * @param index The index of resulted array to get
+     * @return Accessor to manipulate output or continue digging into json further
+     */
+    public ParseResultAccessor get(int index) {
+        return new ParseResultAccessor(result, index);
+    }
+
+    /**
+     * @param key The key of the object
+     * @return Accessor to manipulate output or continue digging into json further
+     */
+    public ParseResultAccessor get(String key) {
+        return new ParseResultAccessor(result, key);
+    }
+
+    @Override
+    public boolean isArray() {
+        return result instanceof JsonArray;
+    }
+
+    @Override
+    public boolean isJsonObject() {
+        return result instanceof JsonObject;
+    }
+
+    @Override
+    public boolean isNull() {
+        return result == null;
+    }
+
+    @Override
+    public JsonObject asJsonObject() {
+        return (JsonObject) result;
+    }
+
+    @Override
+    public JsonArray asArray() {
+        return (JsonArray) result;
+    }
+
+    public static class ParseResultAccessor implements Accessor {
+        private Object init;
+
+        public ParseResultAccessor(Jsonable init, int first) {
+            this.init = init;
+            get(first);
+        }
+
+        public ParseResultAccessor(Jsonable init, String first) {
+            this.init = init;
+            get(first);
+        }
+
+        /**
+         * Used if current element is {@link JsonArray} and it's needed to continue by index
+         * @param index Index in the array
+         * @return Array element accessor
+         */
+        public ParseResultAccessor get(int index) {
+            this.init = ((JsonArray)this.init).get(index);
+            return this;
+        }
+
+        /**
+         * Used if current element is {@link JsonObject} and it's needed to continue by string key
+         * @param key Key in the object
+         * @return Object element accessor
+         */
+        public ParseResultAccessor get(String key) {
+            this.init = ((JsonObject)this.init).get(key);
+            return this;
+        }
+
+        /**
+         * Used if it's needed to save current JSON position in the variable, for example to reduce amount of code
+         * when needed objects are in the same root object
+         * @return Parse result on the current point of the accessor
+         */
+        public ParseResult fixate() {
+            return new ParseResult((Jsonable) init);
+        }
+
+        // Methods used to convert current position to needed objects
+
+        public int asInt() {
+            return asNumber().intValue();
+        }
+
+        public double asDouble() {
+            return asNumber().doubleValue();
+        }
+
+        public float asFloat() {
+            return asNumber().floatValue();
+        }
+
+        public long asLong() {
+            return asNumber().longValue();
+        }
+
+        public BigDecimal asNumber() {
+            return (BigDecimal) init;
+        }
+
+        public boolean asBoolean() {
+            try {
+                return (boolean) init;
+            } catch (ClassCastException exception) {
+                String val = init.toString();
+                if(val.equalsIgnoreCase("true")) {
+                    return true;
+                } else if(val.equals("false")) {
+                    return false;
+                } else {
+                    throw new ClassCastException("Invalid boolean literal at " + ((Jsonable) init).toJson());
+                }
+            }
+        }
+
+        public String asString() {
+            return init.toString();
+        }
+
+        @Override
+        public JsonArray asArray() {
+            return (JsonArray) init;
+        }
+
+        @Override
+        public JsonObject asJsonObject() {
+            return (JsonObject) init;
+        }
+
+        @Override
+        public boolean isArray() {
+            return init instanceof JsonArray;
+        }
+
+        @Override
+        public boolean isJsonObject() {
+            return init instanceof JsonObject;
+        }
+
+        @Override
+        public boolean isNull() {
+            return init == null;
+        }
+    }
+}

--- a/src/test/java/com/github/cliftonlabs/json_simple/JsonerTest.java
+++ b/src/test/java/com/github/cliftonlabs/json_simple/JsonerTest.java
@@ -502,4 +502,16 @@ public class JsonerTest{
 		Jsoner.serializeCarelessly("ABCDEFGHIJKLMNOPQRSTUVWXYZ<>:{}abcdefghijklmnopqrstuvwxyz,.;'[]/`123456789-=~!@#$%^&*_+()\r\b\n\t\f\\К௪ၐᎺអὲ⍚❂⼒ぐ㋺ꁐꁚꑂ\u4e2d", serialized);
 		Assert.assertEquals("\"ABCDEFGHIJKLMNOPQRSTUVWXYZ<>:{}abcdefghijklmnopqrstuvwxyz,.;'[]/`123456789-=~!@#$%^&*_+()\\r\\b\\n\\t\\f\\\\К௪ၐᎺអὲ⍚❂⼒ぐ㋺ꁐꁚꑂ中\"", serialized.toString());
 	}
+
+	/** Ensures fast navigation's work
+	 * @throws JsonException if the test fails. */
+	@Test
+	public void testNavigatedSerialization() throws JsonException {
+		ParseResult result = Jsoner.deserializeWrapped("{\"first\": 123, \"second\": [{\"k1\":{\"id\":\"id1\"}}, 4, 5, 6, {\"id\": 123}], \"third\": 789, \"id\": null}");
+		Assert.assertEquals(result.get("first").asInt(), 123);
+		Assert.assertEquals(result.get("second").get(0).get("k1").get("id").asString(), "id1");
+		Assert.assertEquals(result.get("second").get(4).get("id").asInt(), 123);
+		Assert.assertEquals(result.get("second").get(1).asInt(), 4);
+		Assert.assertTrue(result.get("id").isNull());
+	}
 }


### PR DESCRIPTION
With my change all users of the lib would be able to efficiently navigate through JSON in Builder-like methods.
Example (from the Test)

```java
ParseResult result = Jsoner.deserializeWrapped("{\"first\": 123, \"second\": [{\"k1\":{\"id\":\"id1\"}}, 4, 5, 6, {\"id\": 123}], \"third\": 789, \"id\": null}");
Assert.assertEquals(result.get("first").asInt(), 123);
Assert.assertEquals(result.get("second").get(0).get("k1").get("id").asString(), "id1");
Assert.assertEquals(result.get("second").get(4).get("id").asInt(), 123);
Assert.assertEquals(result.get("second").get(1).asInt(), 4);
Assert.assertTrue(result.get("id").isNull());
```